### PR TITLE
Add 4.08 compiler build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,5 +28,10 @@ env:
   - PACKAGE="aws-async" DISTRO="ubuntu-18.04" OCAML_VERSION="4.07"
   - PACKAGE="aws-gen"   DISTRO="ubuntu-18.04" OCAML_VERSION="4.07"
 
+  - PACKAGE="aws"       DISTRO="ubuntu-18.04" OCAML_VERSION="4.08"
+  - PACKAGE="aws-lwt"   DISTRO="ubuntu-18.04" OCAML_VERSION="4.08"
+  - PACKAGE="aws-async" DISTRO="ubuntu-18.04" OCAML_VERSION="4.08"
+  - PACKAGE="aws-gen"   DISTRO="ubuntu-18.04" OCAML_VERSION="4.08"
+
 os:
   - linux

--- a/aws-async.opam
+++ b/aws-async.opam
@@ -17,6 +17,6 @@ depends: [
   "aws"          {>= "1.0.2"}
   "async"
   "cohttp"
-  "cohttp-async" {>= "0.99"}
+  "cohttp-async"
   "dune" {build}
 ]


### PR DESCRIPTION
I tried adding builds for 4.08 but it seems like opam fails to find a solution that involves async at the moment.

Still opening that PR in the meantime, maybe if Jane Street publishes a set of new point releases that work better with 4.08 it would work.