### PR TITLE
Do not use `Pervasives` anymore

### DIFF
--- a/lib/aws.ml
+++ b/lib/aws.ml
@@ -430,7 +430,7 @@ module Signing = struct
             | [x] -> Uri.pct_encode ~component:`Authority x
             | _ -> failwith "AWS query cannot have multiple values for same key" in
           (key, value)) ps in
-      let sorted = List.sort (fun a b -> Pervasives.compare (fst a) (fst b)) encoded in
+      let sorted = List.sort (fun a b -> compare (fst a) (fst b)) encoded in
       let joined = List.map (fun (k,v) -> k ^ "=" ^ v) sorted in
       String.concat "&" joined
 

--- a/src/structures.ml
+++ b/src/structures.ml
@@ -43,7 +43,7 @@ module Error = struct
     ; http_code : int option }
 
   let compare t1 t2 =
-    Pervasives.compare
+    compare
       (t1.string_name, t1.variant_name, t1.http_code)
       (t2.string_name, t2.variant_name, t2.http_code)
 end


### PR DESCRIPTION
In 4.07 this was replaced by `Stdlib` (and made a warning in 4.08 which makes compilation in dune abort) which would require depending on `stdlib-shims` for older OCaml versions. But since `Pervasives`/`Stdlib` is opened automatically we can just avoid the issue and use the unqualified names. A little ugly, yes, but saves a sort of annoying dependency.