### PR TITLE
Digestif instead of nocrypto

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,22 +83,6 @@ let main () =
 Scheduler.go_main ~main ()
 ```
 
-### FreeBSD
-
-In order to install the library dependencies&mdash;specifically zarith which is
-a transitive dependency of nocrypto&mdash;you must first make the following
-modifications to your system and environment:
-
-```bash
-# zarith asusmes an installation of gcc
-sudo ln /usr/bin/cc /usr/local/bin/gcc
-
-# libgmp-associated files are installed in /usr/local, which is not in the
-# default search path for clang.
-export CLFAGS=-I/usr/local/include
-export LDFLAGS=-L/usr/local/lib
-```
-
 ## License
 
 BSD3, see LICENSE file for its text.

--- a/aws.opam
+++ b/aws.opam
@@ -23,7 +23,7 @@ build: [
 depends: [
   "calendar"
   "ezxmlm"
-  "nocrypto"
+  "digestif"
   "dune" {build}
   "uri" {>= "1.4.0"}
 ]

--- a/lib/aws.ml
+++ b/lib/aws.ml
@@ -400,19 +400,15 @@ module Signing = struct
 
     module Hash = struct
       let _sha256 ?key str =
-        let open Nocrypto.Hash.SHA256 in
-        let bits = Cstruct.of_string str in
         match key with
-        | None   -> digest bits
-        | Some k -> hmac ~key:(Cstruct.of_string k) bits
+        | Some key -> Digestif.SHA256.hmac_string ~key str
+        | None -> Digestif.SHA256.digest_string str
 
       let sha256 ?key str =
-        Cstruct.to_string (_sha256 ?key str)
+	_sha256 ?key str |> Digestif.SHA256.to_raw_string
 
       let sha256_hex ?key str =
-        let buf = Buffer.create 65 in
-        Cstruct.hexdump_to_buffer buf (_sha256 ?key str);
-        Str.(global_replace (regexp "[ \n]")) "" (Buffer.contents buf)
+        _sha256 ?key str |> Digestif.SHA256.to_hex
     end
 
     let encode_query ps =

--- a/lib/dune
+++ b/lib/dune
@@ -2,4 +2,4 @@
  (name aws)
  (public_name aws)
  (wrapped true)
- (libraries uri calendar ezxmlm nocrypto))
+ (libraries uri calendar ezxmlm digestif.c))

--- a/lib/dune
+++ b/lib/dune
@@ -1,5 +1,4 @@
 (library
  (name aws)
  (public_name aws)
- (wrapped true)
  (libraries uri calendar ezxmlm digestif.c))


### PR DESCRIPTION
Since ocaml-aws does not use any of the cryptography in nocrypto but nocrypto creates issues for FreeBSD via Zarith it makes sense to switch to Digestif.

The latter has a simpler API (not requireing Cstruct) and is potentially friendlier to Mirage users (due to a pure OCaml implementation existing) without a complex dependency structure. Also, it is part of the Mirage project and its principal author is known for high-quality libraries.