### PR TITLE
Do not make Dune a build dependency

### DIFF
--- a/async/dune
+++ b/async/dune
@@ -1,5 +1,4 @@
 (library
  (name aws_async)
   (public_name aws-async)
-  (wrapped true)
   (libraries async aws cohttp cohttp-async))

--- a/aws-async.opam
+++ b/aws-async.opam
@@ -19,5 +19,5 @@ depends: [
   "async"
   "cohttp"
   "cohttp-async"
-  "dune" {build}
+  "dune"
 ]

--- a/aws-gen.opam
+++ b/aws-gen.opam
@@ -23,5 +23,5 @@ depends: [
   "yojson" {>="1.6.0"}
   "ocaml-migrate-parsetree"
   "ocamlgraph"
-  "dune" {build}
+  "dune"
 ]

--- a/aws-lwt.opam
+++ b/aws-lwt.opam
@@ -20,5 +20,5 @@ depends: [
   "cohttp"
   "cohttp-lwt"
   "cohttp-lwt-unix" {>= "0.99.0"}
-  "dune" {build}
+  "dune"
 ]

--- a/aws.opam
+++ b/aws.opam
@@ -24,6 +24,6 @@ depends: [
   "calendar"
   "ezxmlm"
   "digestif"
-  "dune" {build}
+  "dune"
   "uri" {>= "1.4.0"}
 ]

--- a/aws_autoscaling.opam
+++ b/aws_autoscaling.opam
@@ -18,5 +18,5 @@ build: [
 ]
 depends: [
   "aws" {>= "0.1.0"}
-  "dune" {build}
+  "dune"
 ]

--- a/aws_cloudformation.opam
+++ b/aws_cloudformation.opam
@@ -18,5 +18,5 @@ build: [
 ]
 depends: [
   "aws" {>= "0.1.0"}
-  "dune" {build}
+  "dune"
 ]

--- a/aws_cloudtrail.opam
+++ b/aws_cloudtrail.opam
@@ -18,5 +18,5 @@ build: [
 ]
 depends: [
   "aws" {>= "0.1.0"}
-  "dune" {build}
+  "dune"
 ]

--- a/aws_cloudwatch.opam
+++ b/aws_cloudwatch.opam
@@ -18,5 +18,5 @@ build: [
 ]
 depends: [
   "aws" {>= "0.1.0"}
-  "dune" {build}
+  "dune"
 ]

--- a/aws_ec2.opam
+++ b/aws_ec2.opam
@@ -18,5 +18,5 @@ build: [
 ]
 depends: [
   "aws" {>= "0.1.0"}
-  "dune" {build}
+  "dune"
 ]

--- a/aws_elasticache.opam
+++ b/aws_elasticache.opam
@@ -18,5 +18,5 @@ build: [
 ]
 depends: [
   "aws" {>= "0.1.0"}
-  "dune" {build}
+  "dune"
 ]

--- a/aws_elasticloadbalancing.opam
+++ b/aws_elasticloadbalancing.opam
@@ -18,5 +18,5 @@ build: [
 ]
 depends: [
   "aws" {>= "0.1.0"}
-  "dune" {build}
+  "dune"
 ]

--- a/aws_rds.opam
+++ b/aws_rds.opam
@@ -18,5 +18,5 @@ build: [
 ]
 depends: [
   "aws" {>= "0.1.0"}
-  "dune" {build}
+  "dune"
 ]

--- a/aws_route53.opam
+++ b/aws_route53.opam
@@ -18,5 +18,5 @@ build: [
 ]
 depends: [
   "aws" {>= "0.1.0"}
-  "dune" {build}
+  "dune"
 ]

--- a/aws_s3.opam
+++ b/aws_s3.opam
@@ -18,5 +18,5 @@ build: [
 ]
 depends: [
   "aws" {>= "0.1.0"}
-  "dune" {build}
+  "dune"
 ]

--- a/aws_sdb.opam
+++ b/aws_sdb.opam
@@ -18,5 +18,5 @@ build: [
 ]
 depends: [
   "aws" {>= "0.1.0"}
-  "dune" {build}
+  "dune"
 ]

--- a/aws_sqs.opam
+++ b/aws_sqs.opam
@@ -18,5 +18,5 @@ build: [
 ]
 depends: [
   "aws" {>= "0.1.0"}
-  "dune" {build}
+  "dune"
 ]

--- a/aws_ssm.opam
+++ b/aws_ssm.opam
@@ -18,5 +18,5 @@ build: [
 ]
 depends: [
   "aws" {>= "0.1.0"}
-  "dune" {build}
+  "dune"
 ]

--- a/aws_sts.opam
+++ b/aws_sts.opam
@@ -18,5 +18,5 @@ build: [
 ]
 depends: [
   "aws" {>= "0.1.0"}
-  "dune" {build}
+  "dune"
 ]

--- a/lwt/dune
+++ b/lwt/dune
@@ -1,5 +1,4 @@
 (library
  (name aws_lwt)
  (public_name aws-lwt)
- (wrapped true)
  (libraries lwt aws cohttp cohttp-lwt cohttp-lwt-unix))

--- a/src/templates.ml
+++ b/src/templates.ml
@@ -51,7 +51,7 @@ build: [
 ]
 depends: [
   "aws" {>= "0.1.0"}
-  "dune" {build}
+  "dune"
 ]
 |} service_name service_name
 


### PR DESCRIPTION
It was decided in opam-repository to not make `dune` a build dependency anymore (see  https://github.com/ocaml/opam-repository/pull/14266 and linked discussion for rationale), so this PR follows suit and removes the `{build}` flag on all `opam` files and from the `opam` file template.

This should make it easier to submit to opam-repository in the future.