### PR TITLE
Update versions to 1.2.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,8 @@ update-version:
 	@echo "Set version to $(VERSION)"
 	@gsed -i 's/^version: .*/version: "$(VERSION)"/' *.opam
 	# @gsed -i 's/"\(aws-s3[-a-z]*\)"[ ]*{= .*}/"\1" {= "$(VERSION)" }/' *.opam
-
+	@gsed -i 's/"\(aws-[-a-z]*\)"[ ]*{= .*}/"\1" {= "$(VERSION)" }/' *.opam
+	@gsed -i 's/"\(aws[-a-z]*\)"[ ]*{= .*}/"\1" {= "$(VERSION)" }/' *.opam
 
 update-version: VERSION=$(shell cat CHANGES.md | grep -E '^[0-9]' | head -n 1 | cut -f1 -d':' )
 release: update-version

--- a/aws-async.opam
+++ b/aws-async.opam
@@ -5,6 +5,7 @@ authors: [ "Spiros Eliopoulos <spiros@inhabitedtype.com>"
            "Tim McGilchrist <timmcgil@gmail.com>"]
 synopsis: "Amazon Web Services SDK bindings for async"
 description: "Amazon Web Services SDK bindings for async"
+version: "1.2"
 license: "BSD-3-clause"
 homepage: "https://github.com/inhabitedtype/ocaml-aws"
 dev-repo: "git+https://github.com/inhabitedtype/ocaml-aws.git"
@@ -15,7 +16,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "aws"          {>= "1.0.2"}
+  "aws"          {>= "1.2"}
   "async"
   "cohttp"
   "cohttp-async"

--- a/aws-autoscaling.opam
+++ b/aws-autoscaling.opam
@@ -6,7 +6,7 @@ authors: [ "Spiros Eliopoulos <spiros@inhabitedtype.com>"
          ]
 synopsis: "Amazon Web Services SDK bindings to Auto Scaling"
 description: "Amazon Web Services SDK bindings to Auto Scaling"
-version: "1.1"
+version: "1.2"
 license: "BSD-3-clause"
 homepage: "https://github.com/inhabitedtype/ocaml-aws"
 dev-repo: "git+https://github.com/inhabitedtype/ocaml-aws.git"

--- a/aws-cloudformation.opam
+++ b/aws-cloudformation.opam
@@ -6,7 +6,7 @@ authors: [ "Spiros Eliopoulos <spiros@inhabitedtype.com>"
          ]
 synopsis: "Amazon Web Services SDK bindings to AWS CloudFormation"
 description: "Amazon Web Services SDK bindings to AWS CloudFormation"
-version: "1.1"
+version: "1.2"
 license: "BSD-3-clause"
 homepage: "https://github.com/inhabitedtype/ocaml-aws"
 dev-repo: "git+https://github.com/inhabitedtype/ocaml-aws.git"

--- a/aws-cloudtrail.opam
+++ b/aws-cloudtrail.opam
@@ -6,7 +6,7 @@ authors: [ "Spiros Eliopoulos <spiros@inhabitedtype.com>"
          ]
 synopsis: "Amazon Web Services SDK bindings to AWS CloudTrail"
 description: "Amazon Web Services SDK bindings to AWS CloudTrail"
-version: "1.1"
+version: "1.2"
 license: "BSD-3-clause"
 homepage: "https://github.com/inhabitedtype/ocaml-aws"
 dev-repo: "git+https://github.com/inhabitedtype/ocaml-aws.git"

--- a/aws-cloudwatch.opam
+++ b/aws-cloudwatch.opam
@@ -6,7 +6,7 @@ authors: [ "Spiros Eliopoulos <spiros@inhabitedtype.com>"
          ]
 synopsis: "Amazon Web Services SDK bindings to Amazon CloudWatch"
 description: "Amazon Web Services SDK bindings to Amazon CloudWatch"
-version: "1.1"
+version: "1.2"
 license: "BSD-3-clause"
 homepage: "https://github.com/inhabitedtype/ocaml-aws"
 dev-repo: "git+https://github.com/inhabitedtype/ocaml-aws.git"

--- a/aws-ec2.opam
+++ b/aws-ec2.opam
@@ -6,7 +6,7 @@ authors: [ "Spiros Eliopoulos <spiros@inhabitedtype.com>"
          ]
 synopsis: "Amazon Web Services SDK bindings to Amazon Elastic Compute Cloud"
 description: "Amazon Web Services SDK bindings to Amazon Elastic Compute Cloud"
-version: "1.1"
+version: "1.2"
 license: "BSD-3-clause"
 homepage: "https://github.com/inhabitedtype/ocaml-aws"
 dev-repo: "git+https://github.com/inhabitedtype/ocaml-aws.git"

--- a/aws-elasticache.opam
+++ b/aws-elasticache.opam
@@ -6,7 +6,7 @@ authors: [ "Spiros Eliopoulos <spiros@inhabitedtype.com>"
          ]
 synopsis: "Amazon Web Services SDK bindings to Amazon ElastiCache"
 description: "Amazon Web Services SDK bindings to Amazon ElastiCache"
-version: "1.1"
+version: "1.2"
 license: "BSD-3-clause"
 homepage: "https://github.com/inhabitedtype/ocaml-aws"
 dev-repo: "git+https://github.com/inhabitedtype/ocaml-aws.git"

--- a/aws-elasticloadbalancing.opam
+++ b/aws-elasticloadbalancing.opam
@@ -6,7 +6,7 @@ authors: [ "Spiros Eliopoulos <spiros@inhabitedtype.com>"
          ]
 synopsis: "Amazon Web Services SDK bindings to Elastic Load Balancing"
 description: "Amazon Web Services SDK bindings to Elastic Load Balancing"
-version: "1.1"
+version: "1.2"
 license: "BSD-3-clause"
 homepage: "https://github.com/inhabitedtype/ocaml-aws"
 dev-repo: "git+https://github.com/inhabitedtype/ocaml-aws.git"

--- a/aws-lwt.opam
+++ b/aws-lwt.opam
@@ -5,6 +5,7 @@ authors: [ "Spiros Eliopoulos <spiros@inhabitedtype.com>"
            "Tim McGilchrist <timmcgil@gmail.com>"]
 synopsis: "Amazon Web Services SDK bindings for lwt"
 description: "Amazon Web Services SDK bindings for lwt"
+version: "1.2"
 license: "BSD-3-clause"
 homepage: "https://github.com/inhabitedtype/ocaml-aws"
 dev-repo: "git+https://github.com/inhabitedtype/ocaml-aws.git"
@@ -15,7 +16,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "aws"             {>= "1.0.2"}
+  "aws"             {>= "1.2"}
   "lwt"             {>= "4.0.0"}
   "cohttp"
   "cohttp-lwt"

--- a/aws-rds.opam
+++ b/aws-rds.opam
@@ -6,7 +6,7 @@ authors: [ "Spiros Eliopoulos <spiros@inhabitedtype.com>"
          ]
 synopsis: "Amazon Web Services SDK bindings to Amazon Relational Database Service"
 description: "Amazon Web Services SDK bindings to Amazon Relational Database Service"
-version: "1.1"
+version: "1.2"
 license: "BSD-3-clause"
 homepage: "https://github.com/inhabitedtype/ocaml-aws"
 dev-repo: "git+https://github.com/inhabitedtype/ocaml-aws.git"

--- a/aws-route53.opam
+++ b/aws-route53.opam
@@ -6,7 +6,7 @@ authors: [ "Spiros Eliopoulos <spiros@inhabitedtype.com>"
          ]
 synopsis: "Amazon Web Services SDK bindings to Amazon Route 53"
 description: "Amazon Web Services SDK bindings to Amazon Route 53"
-version: "1.1"
+version: "1.2"
 license: "BSD-3-clause"
 homepage: "https://github.com/inhabitedtype/ocaml-aws"
 dev-repo: "git+https://github.com/inhabitedtype/ocaml-aws.git"

--- a/aws-sdb.opam
+++ b/aws-sdb.opam
@@ -6,7 +6,7 @@ authors: [ "Spiros Eliopoulos <spiros@inhabitedtype.com>"
          ]
 synopsis: "Amazon Web Services SDK bindings to Amazon SimpleDB"
 description: "Amazon Web Services SDK bindings to Amazon SimpleDB"
-version: "1.1"
+version: "1.2"
 license: "BSD-3-clause"
 homepage: "https://github.com/inhabitedtype/ocaml-aws"
 dev-repo: "git+https://github.com/inhabitedtype/ocaml-aws.git"

--- a/aws-sqs.opam
+++ b/aws-sqs.opam
@@ -6,7 +6,7 @@ authors: [ "Spiros Eliopoulos <spiros@inhabitedtype.com>"
          ]
 synopsis: "Amazon Web Services SDK bindings to Amazon Simple Queue Service"
 description: "Amazon Web Services SDK bindings to Amazon Simple Queue Service"
-version: "1.1"
+version: "1.2"
 license: "BSD-3-clause"
 homepage: "https://github.com/inhabitedtype/ocaml-aws"
 dev-repo: "git+https://github.com/inhabitedtype/ocaml-aws.git"

--- a/aws-ssm.opam
+++ b/aws-ssm.opam
@@ -6,7 +6,7 @@ authors: [ "Spiros Eliopoulos <spiros@inhabitedtype.com>"
          ]
 synopsis: "Amazon Web Services SDK bindings to Amazon Simple Systems Management Service"
 description: "Amazon Web Services SDK bindings to Amazon Simple Systems Management Service"
-version: "1.1"
+version: "1.2"
 license: "BSD-3-clause"
 homepage: "https://github.com/inhabitedtype/ocaml-aws"
 dev-repo: "git+https://github.com/inhabitedtype/ocaml-aws.git"

--- a/aws-sts.opam
+++ b/aws-sts.opam
@@ -6,7 +6,7 @@ authors: [ "Spiros Eliopoulos <spiros@inhabitedtype.com>"
          ]
 synopsis: "Amazon Web Services SDK bindings to AWS Security Token Service"
 description: "Amazon Web Services SDK bindings to AWS Security Token Service"
-version: "1.1"
+version: "1.2"
 license: "BSD-3-clause"
 homepage: "https://github.com/inhabitedtype/ocaml-aws"
 dev-repo: "git+https://github.com/inhabitedtype/ocaml-aws.git"

--- a/aws.opam
+++ b/aws.opam
@@ -11,6 +11,7 @@ distribution includes a core runtime API and a code generation tool
 that generates individual libraries from [botocore][] service
 descriptions.
 """
+version: "1.2"
 license: "BSD-3-clause"
 homepage: "https://github.com/inhabitedtype/ocaml-aws"
 dev-repo: "git+https://github.com/inhabitedtype/ocaml-aws.git"


### PR DESCRIPTION
Required before releasing 1.2 to opam:
- [x]  elasticache (Needs updated botocore) https://github.com/inhabitedtype/ocaml-aws/pull/82
- [x]  s3 (Remove temporarily due to broken de-serialisation code)https://github.com/inhabitedtype/ocaml-aws/pull/92 https://github.com/inhabitedtype/ocaml-aws/pull/103
- [x]  sdb (Requires Signature V2 implementation)https://github.com/inhabitedtype/ocaml-aws/pull/100
- [x]  sts (Broken de-serialisation code and requires recursive modules in code generation) https://github.com/inhabitedtype/ocaml-aws/pull/98
- [x] documentation publishing to http://inhabitedtype.github.io/ocaml-aws/
- [x] Update botocore for all working services. #90 #89 #88 #87 #86 #85 #84  #82 