### PR TITLE
Add support for sts assume_role tokens

### DIFF
--- a/async/runtime.ml
+++ b/async/runtime.ml
@@ -44,6 +44,7 @@ let run_request
     ~region
     ~access_key
     ~secret_key
+    ?token
     (module M : Aws.Call
       with type input = input
        and type output = output
@@ -54,6 +55,7 @@ let run_request
       ~access_key
       ~secret_key
       ~service:M.service
+      ?token
       ~region
       (M.to_http M.service region inp)
   in

--- a/async/runtime.mli
+++ b/async/runtime.mli
@@ -35,6 +35,7 @@ val run_request :
      region:string
   -> access_key:string
   -> secret_key:string
+  -> ?token:string
   -> ('input, 'output, 'error) Aws.call
   -> 'input
   -> [ `Ok of 'output | `Error of 'error Aws.Error.t ] Async.Deferred.t

--- a/lib/aws.ml
+++ b/lib/aws.ml
@@ -246,7 +246,7 @@ module Query = struct
       | k, List xs -> List.concat (List.map (enc k) xs)
       | Some n, Pair (label, subq) -> enc (Some (n ^ "." ^ label)) subq
       | None, Pair (label, subq) -> enc (Some label) subq
-      | Some n, Value (Some s) -> [ n ^ "=" ^ Uri.pct_encode s ]
+      | Some n, Value (Some s) -> [ n ^ "=" ^ Uri.pct_encode ~component:`Query_value s ]
       | None, Value (Some s) -> [ Uri.pct_encode s ]
       | Some s, _ -> [ s ]
       | _ -> []
@@ -501,7 +501,7 @@ module Signing = struct
   (* NOTE(dbp 2015-01-13): This is a direct translation of reference implementation at:
    * http://docs.aws.amazon.com/general/latest/gr/sigv4-signed-request-examples.html
    *)
-  let sign_request ~access_key ~secret_key ~service ~region (meth, uri, headers) =
+  let sign_request ~access_key ~secret_key ?token ~service ~region (meth, uri, headers) =
     let host = Util.of_option_exn (Endpoints.endpoint_of service region) in
     let params = encode_query (Uri.query uri) in
     let sign key msg = Hash.sha256 ~key msg in
@@ -514,6 +514,14 @@ module Signing = struct
     let canonical_uri = "/" in
     let canonical_querystring = params in
     let payload_hash = Hash.sha256_hex "" in
+    let token_header, sig_header = match token with
+    | Some t ->
+      let th = "x-amz-security-token:" ^ t ^ "\n" in
+      let sh = ";x-amz-security-token" in
+      th, sh
+    | None ->
+      "", ""
+    in
     let canonical_headers =
       "host:"
       ^ host
@@ -523,8 +531,9 @@ module Signing = struct
       ^ "\nx-amz-date:"
       ^ amzdate
       ^ "\n"
+      ^ token_header
     in
-    let signed_headers = "host;x-amz-content-sha256;x-amz-date" in
+    let signed_headers = "host;x-amz-content-sha256;x-amz-date" ^ sig_header in
     let canonical_request =
       Request.string_of_meth meth
       ^ "\n"
@@ -576,5 +585,9 @@ module Signing = struct
       :: ("Authorization", authorization_header)
       :: headers
     in
-    meth, uri, headers
+    let full_headers = match token with
+    | Some t -> ("X-Amz-Security-Token", t) :: headers
+    | None -> headers
+    in
+    meth, uri, full_headers
 end

--- a/lib/aws.mli
+++ b/lib/aws.mli
@@ -281,6 +281,7 @@ module Signing : sig
   val sign_request :
        access_key:string
     -> secret_key:string
+    -> ?token:string
     -> service:string
     -> region:string
     -> Request.t

--- a/libraries/s3/lib_test/test_async.ml
+++ b/libraries/s3/lib_test/test_async.ml
@@ -3,11 +3,13 @@ open Aws_s3_test
 module T = TestSuite (struct
   type 'a m = 'a Async.Deferred.t
 
-  let access_key = Unix.getenv "AWS_ACCESS_KEY"
+  let access_key = Unix.getenv "AWS_ACCESS_KEY_ID"
 
-  let secret_key = Unix.getenv "AWS_SECRET_KEY"
+  let secret_key = Unix.getenv "AWS_SECRET_ACCESS_KEY"
 
-  let run_request = Aws_async.Runtime.run_request ~access_key ~secret_key
+  let token = None
+
+  let run_request = Aws_async.Runtime.run_request ~access_key ~secret_key ?token
 
   let un_m v = Async.Thread_safe.block_on_async_exn (fun () -> v)
 end)

--- a/libraries/s3/lib_test/test_lwt.ml
+++ b/libraries/s3/lib_test/test_lwt.ml
@@ -3,11 +3,13 @@ open Aws_s3_test
 module T = TestSuite (struct
   type 'a m = 'a Lwt.t
 
-  let access_key = Unix.getenv "AWS_ACCESS_KEY"
+  let access_key = Unix.getenv "AWS_ACCESS_KEY_ID"
 
-  let secret_key = Unix.getenv "AWS_SECRET_KEY"
+  let secret_key = Unix.getenv "AWS_SECRET_ACCESS_KEY"
 
-  let run_request = Aws_lwt.Runtime.run_request ~access_key ~secret_key
+  let token = None
+
+  let run_request = Aws_lwt.Runtime.run_request ~access_key ~secret_key ?token
 
   let un_m = Lwt_main.run
 end)

--- a/lwt/runtime.ml
+++ b/lwt/runtime.ml
@@ -38,6 +38,7 @@ let run_request
     ~region
     ~access_key
     ~secret_key
+    ?token
     (module M : Aws.Call
       with type input = input
        and type output = output
@@ -47,6 +48,7 @@ let run_request
     Aws.Signing.sign_request
       ~access_key
       ~secret_key
+      ?token
       ~service:M.service
       ~region
       (M.to_http M.service region inp)

--- a/lwt/runtime.mli
+++ b/lwt/runtime.mli
@@ -37,6 +37,7 @@ val run_request :
      region:string
   -> access_key:string
   -> secret_key:string
+  -> ?token:string
   -> ('input, 'output, 'error) Aws.call
   -> 'input
   -> [ `Ok of 'output | `Error of 'error Aws.Error.t ] Lwt.t


### PR DESCRIPTION
AWS allows users to authenticate requests with temporary credentials that are requested from the STS service. Doing so requires that the token header is signed and included with the request. This adds an optional parameter to calls to allow for a token parameter to be passed in.

This is working for me and I've successfully incorporated into my code but I'm putting this in draft until I can test it a bit more. Please let me know if you would like anything changed. 

I believe this might solve #76 as well.