### PR TITLE
Fix from 8adfbec323a9847e40331ce46ab5d0a8f03c24d4 addresses failing r…

### DIFF
--- a/libraries/sts/lib_test/aws_sts_test.ml
+++ b/libraries/sts/lib_test/aws_sts_test.ml
@@ -33,8 +33,7 @@ functor
           Printf.printf
             "%s\n"
             (Yojson.Basic.to_string
-               Types.GetSessionTokenResponse.(to_json resp));
-          (* TODO Note round tripping from resp to json from json to json is broken for date time values. *)
+               Types.GetSessionTokenResponse.(to_json (of_json (to_json resp))));
           true
       | `Error err ->
           Printf.printf "Error: %s\n" (Aws.Error.format Errors_internal.to_string err);


### PR DESCRIPTION
…oundtrip test for STS.