### PR TITLE
Rename the Unix Env variables expected in tests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ opam update aws
 
 Running individual test suites for a Service
 ``` bash
-AWS_ACCESS_KEY=???? \
-AWS_SECRET_KEY=???? \
+AWS_ACCESS_KEY_ID=???? \
+AWS_SECRET_ACCESS_KEY=???? \
 AWS_DEFAULT_REGION=ap-southeast-2 \
 dune runtest libraries/ec2/lib_test
 ```

--- a/lib/aws.mli
+++ b/lib/aws.mli
@@ -312,7 +312,7 @@ module Signing : sig
 
       http://docs.aws.amazon.com/general/latest/gr/sigv4-signed-request-examples.html
 
-      Note: This requires AWS_ACCESS_KEY and AWS_SECRET_KEY
+      Note: This requires AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY
       environment variables to be set.
 
       Also: Your system time must be accurate. If you are getting invalid
@@ -332,7 +332,7 @@ module Signing : sig
 
       https://docs.aws.amazon.com/general/latest/gr/signature-version-2.html
 
-      Note: This requires AWS_ACCESS_KEY and AWS_SECRET_KEY
+      Note: This requires AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY
       environment variables to be set.
 
       Also: Your system time must be accurate. If you are getting invalid

--- a/libraries/autoscaling/lib_test/test_async.ml
+++ b/libraries/autoscaling/lib_test/test_async.ml
@@ -3,8 +3,8 @@ open Aws_autoscaling_test
 module T = TestSuite(struct
     type 'a m = 'a Async.Deferred.t
 
-    let access_key = Unix.getenv "AWS_ACCESS_KEY"
-    let secret_key = Unix.getenv "AWS_SECRET_KEY"
+    let access_key = Unix.getenv "AWS_ACCESS_KEY_ID"
+    let secret_key = Unix.getenv "AWS_SECRET_ACCESS_KEY"
     let region = Unix.getenv "AWS_DEFAULT_REGION"
 
     let run_request x = Aws_async.Runtime.run_request ~region ~access_key ~secret_key x

--- a/libraries/autoscaling/lib_test/test_lwt.ml
+++ b/libraries/autoscaling/lib_test/test_lwt.ml
@@ -3,8 +3,8 @@ open Aws_autoscaling_test
 module T = TestSuite(struct
     type 'a m = 'a Lwt.t
 
-    let access_key = Unix.getenv "AWS_ACCESS_KEY"
-    let secret_key = Unix.getenv "AWS_SECRET_KEY"
+    let access_key = Unix.getenv "AWS_ACCESS_KEY_ID"
+    let secret_key = Unix.getenv "AWS_SECRET_ACCESS_KEY"
     let region = Unix.getenv "AWS_DEFAULT_REGION"
 
     let run_request x = Aws_lwt.Runtime.run_request ~region ~access_key ~secret_key x

--- a/libraries/cloudformation/lib_test/test_async.ml
+++ b/libraries/cloudformation/lib_test/test_async.ml
@@ -3,8 +3,8 @@ open Aws_cloudformation_test
 module T = TestSuite(struct
     type 'a m = 'a Async.Deferred.t
 
-    let access_key = Unix.getenv "AWS_ACCESS_KEY"
-    let secret_key = Unix.getenv "AWS_SECRET_KEY"
+    let access_key = Unix.getenv "AWS_ACCESS_KEY_ID"
+    let secret_key = Unix.getenv "AWS_SECRET_ACCESS_KEY"
     let region = Unix.getenv "AWS_DEFAULT_REGION"
 
     let run_request x = Aws_async.Runtime.run_request ~region ~access_key ~secret_key x

--- a/libraries/cloudformation/lib_test/test_lwt.ml
+++ b/libraries/cloudformation/lib_test/test_lwt.ml
@@ -3,8 +3,8 @@ open Aws_cloudformation_test
 module T = TestSuite(struct
     type 'a m = 'a Lwt.t
 
-    let access_key = Unix.getenv "AWS_ACCESS_KEY"
-    let secret_key = Unix.getenv "AWS_SECRET_KEY"
+    let access_key = Unix.getenv "AWS_ACCESS_KEY_ID"
+    let secret_key = Unix.getenv "AWS_SECRET_ACCESS_KEY"
     let region = Unix.getenv "AWS_DEFAULT_REGION"
 
     let run_request x = Aws_lwt.Runtime.run_request ~region ~access_key ~secret_key x

--- a/libraries/cloudtrail/lib_test/test_async.ml
+++ b/libraries/cloudtrail/lib_test/test_async.ml
@@ -3,8 +3,8 @@ open Aws_cloudtrail_test
 module T = TestSuite(struct
     type 'a m = 'a Async.Deferred.t
 
-    let access_key = Unix.getenv "AWS_ACCESS_KEY"
-    let secret_key = Unix.getenv "AWS_SECRET_KEY"
+    let access_key = Unix.getenv "AWS_ACCESS_KEY_ID"
+    let secret_key = Unix.getenv "AWS_SECRET_ACCESS_KEY"
     let region = Unix.getenv "AWS_DEFAULT_REGION"
 
     let run_request x = Aws_async.Runtime.run_request ~region ~access_key ~secret_key x

--- a/libraries/cloudtrail/lib_test/test_lwt.ml
+++ b/libraries/cloudtrail/lib_test/test_lwt.ml
@@ -3,8 +3,8 @@ open Aws_cloudtrail_test
 module T = TestSuite(struct
     type 'a m = 'a Lwt.t
 
-    let access_key = Unix.getenv "AWS_ACCESS_KEY"
-    let secret_key = Unix.getenv "AWS_SECRET_KEY"
+    let access_key = Unix.getenv "AWS_ACCESS_KEY_ID"
+    let secret_key = Unix.getenv "AWS_SECRET_ACCESS_KEY"
     let region = Unix.getenv "AWS_DEFAULT_REGION"
 
     let run_request x = Aws_lwt.Runtime.run_request ~region ~access_key ~secret_key x

--- a/libraries/cloudwatch/lib_test/test_async.ml
+++ b/libraries/cloudwatch/lib_test/test_async.ml
@@ -3,8 +3,8 @@ open Aws_cloudwatch_test
 module T = TestSuite(struct
     type 'a m = 'a Async.Deferred.t
 
-    let access_key = Unix.getenv "AWS_ACCESS_KEY"
-    let secret_key = Unix.getenv "AWS_SECRET_KEY"
+    let access_key = Unix.getenv "AWS_ACCESS_KEY_ID"
+    let secret_key = Unix.getenv "AWS_SECRET_ACCESS_KEY"
     let region = Unix.getenv "AWS_DEFAULT_REGION"
 
     let run_request x = Aws_async.Runtime.run_request ~region ~access_key ~secret_key x

--- a/libraries/cloudwatch/lib_test/test_lwt.ml
+++ b/libraries/cloudwatch/lib_test/test_lwt.ml
@@ -3,8 +3,8 @@ open Aws_cloudwatch_test
 module T = TestSuite(struct
     type 'a m = 'a Lwt.t
 
-    let access_key = Unix.getenv "AWS_ACCESS_KEY"
-    let secret_key = Unix.getenv "AWS_SECRET_KEY"
+    let access_key = Unix.getenv "AWS_ACCESS_KEY_ID"
+    let secret_key = Unix.getenv "AWS_SECRET_ACCESS_KEY"
     let region = Unix.getenv "AWS_DEFAULT_REGION"
 
     let run_request x = Aws_lwt.Runtime.run_request ~region ~access_key ~secret_key x

--- a/libraries/ec2/lib_test/test_async.ml
+++ b/libraries/ec2/lib_test/test_async.ml
@@ -3,8 +3,8 @@ open Aws_ec2_test
 module T = TestSuite(struct
     type 'a m = 'a Async.Deferred.t
 
-    let access_key = Unix.getenv "AWS_ACCESS_KEY"
-    let secret_key = Unix.getenv "AWS_SECRET_KEY"
+    let access_key = Unix.getenv "AWS_ACCESS_KEY_ID"
+    let secret_key = Unix.getenv "AWS_SECRET_ACCESS_KEY"
     let region = Unix.getenv "AWS_DEFAULT_REGION"
 
     let run_request x = Aws_async.Runtime.run_request ~region ~access_key ~secret_key x

--- a/libraries/ec2/lib_test/test_lwt.ml
+++ b/libraries/ec2/lib_test/test_lwt.ml
@@ -3,8 +3,8 @@ open Aws_ec2_test
 module T = TestSuite(struct
     type 'a m = 'a Lwt.t
 
-    let access_key = Unix.getenv "AWS_ACCESS_KEY"
-    let secret_key = Unix.getenv "AWS_SECRET_KEY"
+    let access_key = Unix.getenv "AWS_ACCESS_KEY_ID"
+    let secret_key = Unix.getenv "AWS_SECRET_ACCESS_KEY"
     let region = Unix.getenv "AWS_DEFAULT_REGION"
 
     let run_request x = Aws_lwt.Runtime.run_request ~region ~access_key ~secret_key x

--- a/libraries/elasticache/lib_test/test_async.ml
+++ b/libraries/elasticache/lib_test/test_async.ml
@@ -3,8 +3,8 @@ open Aws_elasticache_test
 module T = TestSuite(struct
     type 'a m = 'a Async.Deferred.t
 
-    let access_key = Unix.getenv "AWS_ACCESS_KEY"
-    let secret_key = Unix.getenv "AWS_SECRET_KEY"
+    let access_key = Unix.getenv "AWS_ACCESS_KEY_ID"
+    let secret_key = Unix.getenv "AWS_SECRET_ACCESS_KEY"
     let region = Unix.getenv "AWS_DEFAULT_REGION"
 
     let run_request x = Aws_async.Runtime.run_request ~region ~access_key ~secret_key x

--- a/libraries/elasticache/lib_test/test_lwt.ml
+++ b/libraries/elasticache/lib_test/test_lwt.ml
@@ -3,8 +3,8 @@ open Aws_elasticache_test
 module T = TestSuite(struct
     type 'a m = 'a Lwt.t
 
-    let access_key = Unix.getenv "AWS_ACCESS_KEY"
-    let secret_key = Unix.getenv "AWS_SECRET_KEY"
+    let access_key = Unix.getenv "AWS_ACCESS_KEY_ID"
+    let secret_key = Unix.getenv "AWS_SECRET_ACCESS_KEY"
     let region = Unix.getenv "AWS_DEFAULT_REGION"
 
     let run_request x = Aws_lwt.Runtime.run_request ~region ~access_key ~secret_key x

--- a/libraries/elasticloadbalancing/lib_test/test_async.ml
+++ b/libraries/elasticloadbalancing/lib_test/test_async.ml
@@ -3,8 +3,8 @@ open Aws_elasticloadbalancing_test
 module T = TestSuite(struct
     type 'a m = 'a Async.Deferred.t
 
-    let access_key = Unix.getenv "AWS_ACCESS_KEY"
-    let secret_key = Unix.getenv "AWS_SECRET_KEY"
+    let access_key = Unix.getenv "AWS_ACCESS_KEY_ID"
+    let secret_key = Unix.getenv "AWS_SECRET_ACCESS_KEY"
     let region = Unix.getenv "AWS_DEFAULT_REGION"
 
     let run_request x = Aws_async.Runtime.run_request ~region ~access_key ~secret_key x

--- a/libraries/elasticloadbalancing/lib_test/test_lwt.ml
+++ b/libraries/elasticloadbalancing/lib_test/test_lwt.ml
@@ -3,8 +3,8 @@ open Aws_elasticloadbalancing_test
 module T = TestSuite(struct
     type 'a m = 'a Lwt.t
 
-    let access_key = Unix.getenv "AWS_ACCESS_KEY"
-    let secret_key = Unix.getenv "AWS_SECRET_KEY"
+    let access_key = Unix.getenv "AWS_ACCESS_KEY_ID"
+    let secret_key = Unix.getenv "AWS_SECRET_ACCESS_KEY"
     let region = Unix.getenv "AWS_DEFAULT_REGION"
 
     let run_request x = Aws_lwt.Runtime.run_request ~region ~access_key ~secret_key x

--- a/libraries/rds/lib_test/test_async.ml
+++ b/libraries/rds/lib_test/test_async.ml
@@ -3,8 +3,8 @@ open Aws_rds_test
 module T = TestSuite(struct
     type 'a m = 'a Async.Deferred.t
 
-    let access_key = Unix.getenv "AWS_ACCESS_KEY"
-    let secret_key = Unix.getenv "AWS_SECRET_KEY"
+    let access_key = Unix.getenv "AWS_ACCESS_KEY_ID"
+    let secret_key = Unix.getenv "AWS_SECRET_ACCESS_KEY"
     let region = Unix.getenv "AWS_DEFAULT_REGION"
 
     let run_request x = Aws_async.Runtime.run_request ~region ~access_key ~secret_key x

--- a/libraries/rds/lib_test/test_lwt.ml
+++ b/libraries/rds/lib_test/test_lwt.ml
@@ -3,8 +3,8 @@ open Aws_rds_test
 module T = TestSuite(struct
     type 'a m = 'a Lwt.t
 
-    let access_key = Unix.getenv "AWS_ACCESS_KEY"
-    let secret_key = Unix.getenv "AWS_SECRET_KEY"
+    let access_key = Unix.getenv "AWS_ACCESS_KEY_ID"
+    let secret_key = Unix.getenv "AWS_SECRET_ACCESS_KEY"
     let region = Unix.getenv "AWS_DEFAULT_REGION"
 
     let run_request x = Aws_lwt.Runtime.run_request ~region ~access_key ~secret_key x

--- a/libraries/route53/lib_test/test_async.ml
+++ b/libraries/route53/lib_test/test_async.ml
@@ -3,8 +3,8 @@ open Aws_route53_test
 module T = TestSuite(struct
     type 'a m = 'a Async.Deferred.t
 
-    let access_key = Unix.getenv "AWS_ACCESS_KEY"
-    let secret_key = Unix.getenv "AWS_SECRET_KEY"
+    let access_key = Unix.getenv "AWS_ACCESS_KEY_ID"
+    let secret_key = Unix.getenv "AWS_SECRET_ACCESS_KEY"
     let region = Unix.getenv "AWS_DEFAULT_REGION"
 
     let run_request x = Aws_async.Runtime.run_request ~region ~access_key ~secret_key x

--- a/libraries/route53/lib_test/test_lwt.ml
+++ b/libraries/route53/lib_test/test_lwt.ml
@@ -3,8 +3,8 @@ open Aws_route53_test
 module T = TestSuite(struct
     type 'a m = 'a Lwt.t
 
-    let access_key = Unix.getenv "AWS_ACCESS_KEY"
-    let secret_key = Unix.getenv "AWS_SECRET_KEY"
+    let access_key = Unix.getenv "AWS_ACCESS_KEY_ID"
+    let secret_key = Unix.getenv "AWS_SECRET_ACCESS_KEY"
     let region = Unix.getenv "AWS_DEFAULT_REGION"
 
     let run_request x = Aws_lwt.Runtime.run_request ~region ~access_key ~secret_key x

--- a/libraries/sdb/lib_test/test_async.ml
+++ b/libraries/sdb/lib_test/test_async.ml
@@ -3,8 +3,8 @@ open Aws_sdb_test
 module T = TestSuite(struct
     type 'a m = 'a Async.Deferred.t
 
-    let access_key = Unix.getenv "AWS_ACCESS_KEY"
-    let secret_key = Unix.getenv "AWS_SECRET_KEY"
+    let access_key = Unix.getenv "AWS_ACCESS_KEY_ID"
+    let secret_key = Unix.getenv "AWS_SECRET_ACCESS_KEY"
     let region = Unix.getenv "AWS_DEFAULT_REGION"
 
     let run_request x = Aws_async.Runtime.run_request ~region ~access_key ~secret_key x

--- a/libraries/sdb/lib_test/test_lwt.ml
+++ b/libraries/sdb/lib_test/test_lwt.ml
@@ -3,8 +3,8 @@ open Aws_sdb_test
 module T = TestSuite(struct
     type 'a m = 'a Lwt.t
 
-    let access_key = Unix.getenv "AWS_ACCESS_KEY"
-    let secret_key = Unix.getenv "AWS_SECRET_KEY"
+    let access_key = Unix.getenv "AWS_ACCESS_KEY_ID"
+    let secret_key = Unix.getenv "AWS_SECRET_ACCESS_KEY"
     let region = Unix.getenv "AWS_DEFAULT_REGION"
 
     let run_request x = Aws_lwt.Runtime.run_request ~region ~access_key ~secret_key x

--- a/libraries/sqs/lib_test/test_async.ml
+++ b/libraries/sqs/lib_test/test_async.ml
@@ -3,8 +3,8 @@ open Aws_sqs_test
 module T = TestSuite(struct
     type 'a m = 'a Async.Deferred.t
 
-    let access_key = Unix.getenv "AWS_ACCESS_KEY"
-    let secret_key = Unix.getenv "AWS_SECRET_KEY"
+    let access_key = Unix.getenv "AWS_ACCESS_KEY_ID"
+    let secret_key = Unix.getenv "AWS_SECRET_ACCESS_KEY"
     let region = Unix.getenv "AWS_DEFAULT_REGION"
 
     let run_request x = Aws_async.Runtime.run_request ~region ~access_key ~secret_key x

--- a/libraries/sqs/lib_test/test_lwt.ml
+++ b/libraries/sqs/lib_test/test_lwt.ml
@@ -3,8 +3,8 @@ open Aws_sqs_test
 module T = TestSuite(struct
     type 'a m = 'a Lwt.t
 
-    let access_key = Unix.getenv "AWS_ACCESS_KEY"
-    let secret_key = Unix.getenv "AWS_SECRET_KEY"
+    let access_key = Unix.getenv "AWS_ACCESS_KEY_ID"
+    let secret_key = Unix.getenv "AWS_SECRET_ACCESS_KEY"
     let region = Unix.getenv "AWS_DEFAULT_REGION"
 
     let run_request x = Aws_lwt.Runtime.run_request ~region ~access_key ~secret_key x

--- a/libraries/ssm/lib_test/test_async.ml
+++ b/libraries/ssm/lib_test/test_async.ml
@@ -3,8 +3,8 @@ open Aws_ssm_test
 module T = TestSuite(struct
     type 'a m = 'a Async.Deferred.t
 
-    let access_key = Unix.getenv "AWS_ACCESS_KEY"
-    let secret_key = Unix.getenv "AWS_SECRET_KEY"
+    let access_key = Unix.getenv "AWS_ACCESS_KEY_ID"
+    let secret_key = Unix.getenv "AWS_SECRET_ACCESS_KEY"
     let region = Unix.getenv "AWS_DEFAULT_REGION"
 
     let run_request x = Aws_async.Runtime.run_request ~region ~access_key ~secret_key x

--- a/libraries/ssm/lib_test/test_lwt.ml
+++ b/libraries/ssm/lib_test/test_lwt.ml
@@ -3,8 +3,8 @@ open Aws_ssm_test
 module T = TestSuite(struct
     type 'a m = 'a Lwt.t
 
-    let access_key = Unix.getenv "AWS_ACCESS_KEY"
-    let secret_key = Unix.getenv "AWS_SECRET_KEY"
+    let access_key = Unix.getenv "AWS_ACCESS_KEY_ID"
+    let secret_key = Unix.getenv "AWS_SECRET_ACCESS_KEY"
     let region = Unix.getenv "AWS_DEFAULT_REGION"
 
     let run_request x = Aws_lwt.Runtime.run_request ~region ~access_key ~secret_key x

--- a/libraries/sts/lib_test/test_async.ml
+++ b/libraries/sts/lib_test/test_async.ml
@@ -3,8 +3,8 @@ open Aws_sts_test
 module T = TestSuite(struct
     type 'a m = 'a Async.Deferred.t
 
-    let access_key = Unix.getenv "AWS_ACCESS_KEY"
-    let secret_key = Unix.getenv "AWS_SECRET_KEY"
+    let access_key = Unix.getenv "AWS_ACCESS_KEY_ID"
+    let secret_key = Unix.getenv "AWS_SECRET_ACCESS_KEY"
     let region = Unix.getenv "AWS_DEFAULT_REGION"
 
     let run_request x = Aws_async.Runtime.run_request ~region ~access_key ~secret_key x

--- a/libraries/sts/lib_test/test_lwt.ml
+++ b/libraries/sts/lib_test/test_lwt.ml
@@ -3,8 +3,8 @@ open Aws_sts_test
 module T = TestSuite(struct
     type 'a m = 'a Lwt.t
 
-    let access_key = Unix.getenv "AWS_ACCESS_KEY"
-    let secret_key = Unix.getenv "AWS_SECRET_KEY"
+    let access_key = Unix.getenv "AWS_ACCESS_KEY_ID"
+    let secret_key = Unix.getenv "AWS_SECRET_ACCESS_KEY"
     let region = Unix.getenv "AWS_DEFAULT_REGION"
 
     let run_request x = Aws_lwt.Runtime.run_request ~region ~access_key ~secret_key x

--- a/src/templates.ml
+++ b/src/templates.ml
@@ -110,8 +110,8 @@ let test_async ~lib_name =
 module T = TestSuite(struct
     type 'a m = 'a Async.Deferred.t
 
-    let access_key = Unix.getenv "AWS_ACCESS_KEY"
-    let secret_key = Unix.getenv "AWS_SECRET_KEY"
+    let access_key = Unix.getenv "AWS_ACCESS_KEY_ID_ID"
+    let secret_key = Unix.getenv "AWS_SECRET_ACCESS_KEY"
     let region = Unix.getenv "AWS_DEFAULT_REGION"
 
     let run_request x = Aws_async.Runtime.run_request ~region ~access_key ~secret_key x
@@ -127,8 +127,8 @@ let test_lwt ~lib_name =
 module T = TestSuite(struct
     type 'a m = 'a Lwt.t
 
-    let access_key = Unix.getenv "AWS_ACCESS_KEY"
-    let secret_key = Unix.getenv "AWS_SECRET_KEY"
+    let access_key = Unix.getenv "AWS_ACCESS_KEY_ID_ID"
+    let secret_key = Unix.getenv "AWS_SECRET_ACCESS_KEY"
     let region = Unix.getenv "AWS_DEFAULT_REGION"
 
     let run_request x = Aws_lwt.Runtime.run_request ~region ~access_key ~secret_key x


### PR DESCRIPTION
They now match the AWS CLI supported environment variables.
https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html